### PR TITLE
Enable buildDatabase.sh call without arguments (latest by default)

### DIFF
--- a/database/buildDatabase.sh
+++ b/database/buildDatabase.sh
@@ -7,10 +7,14 @@ export LC_ALL=C
 
 # By default, the latest Wikipedia dump will be downloaded. If a download date in the format
 # YYYYMMDD is provided as the first argument, it will be used instead.
-if [ ${#1} -ne 8 ]; then
+if [ $# -eq 0 ]; then
   DOWNLOAD_DATE="latest"
 else
-  DOWNLOAD_DATE=$1
+  if [ ${#1} -ne 8 ]; then
+    DOWNLOAD_DATE="latest"
+  else
+    DOWNLOAD_DATE=$1
+  fi
 fi
 
 ROOT_DIR=`pwd`


### PR DESCRIPTION
buildDatabase.sh line 10 check fails when you do not pass any argument. I add a check to ensure first argument exists before check first argument length.

This enable calling buildDatabase.sh without any date using latest by default