### PR TITLE
chore(deps): fix uncaught router error

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7462,11 +7462,16 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
     "history": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.0.0.tgz",
-      "integrity": "sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
       "requires": {
-        "@babel/runtime": "^7.7.6"
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
       }
     },
     "hmac-drbg": {

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
     "classnames": "^2.2.5",
     "connected-react-router": "^6.5.2",
     "d3": "^5.1.0",
-    "history": "^5.0.0",
+    "history": "^4.10.1",
     "lodash": "^4.17.21",
     "particles.js": "^2.0.0",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
Downgraded installed history version to 4.10.1 manually
Fixes #61. A deployed version of this PR can be found at https://sdow.netlify.app 