### PR TITLE
Update README.md - fix wrong URL for wiki dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ encyclopedia.
 
 - [Wikipedia API](https://www.mediawiki.org/wiki/API:Main_page)
 - [Wikipedia database layout](https://www.mediawiki.org/wiki/Manual:Database_layout)
-- [English Wikipedia database dumps](https://dumps.wikimedia.your.org/enwiki)
+- [English Wikipedia database dumps](https://dumps.wikimedia.org/enwiki)
 
 ## Contributing
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the URL in the documentation to correctly point to the English Wikipedia database dumps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->