### PR TITLE
update download URLs, fallback to wget when torrent fails

### DIFF
--- a/scripts/buildDatabase.sh
+++ b/scripts/buildDatabase.sh
@@ -9,7 +9,7 @@ export LC_ALL=C
 # By default, the latest Wikipedia dump will be downloaded. If a download date in the format
 # YYYYMMDD is provided as the first argument, it will be used instead.
 if [[ $# -eq 0 ]]; then
-  DOWNLOAD_DATE=$(wget -q -O- https://dumps.wikimedia.your.org/enwiki/ | grep -Po '\d{8}' | sort | tail -n1)
+  DOWNLOAD_DATE=$(wget -q -O- https://dumps.wikimedia.org/enwiki/ | grep -Po '\d{8}' | sort | tail -n1)
 else
   if [ ${#1} -ne 8 ]; then
     echo "[ERROR] Invalid download date provided: $1"
@@ -22,8 +22,8 @@ fi
 ROOT_DIR=`pwd`
 OUT_DIR="dump"
 
-DOWNLOAD_URL="https://dumps.wikimedia.your.org/enwiki/$DOWNLOAD_DATE"
-TORRENT_URL="https://tools.wmflabs.org/dump-torrents/enwiki/$DOWNLOAD_DATE"
+DOWNLOAD_URL="https://dumps.wikimedia.org/enwiki/$DOWNLOAD_DATE"
+TORRENT_URL="https://dump-torrents.toolforge.org/enwiki/$DOWNLOAD_DATE"
 
 SHA1SUM_FILENAME="enwiki-$DOWNLOAD_DATE-sha1sums.txt"
 REDIRECTS_FILENAME="enwiki-$DOWNLOAD_DATE-redirect.sql.gz"
@@ -51,8 +51,10 @@ function download_file() {
     if [ $1 != sha1sums ] && command -v aria2c > /dev/null; then
       echo "[INFO] Downloading $1 file via torrent"
       time aria2c --summary-interval=0 --console-log-level=warn --seed-time=0 \
-        "$TORRENT_URL/$2.torrent"
-    else
+        "$TORRENT_URL/$2.torrent" 2>&1 | grep -v "ERROR\|Exception" || true
+    fi
+    
+    if [ ! -f $2 ]; then
       echo "[INFO] Downloading $1 file via wget"
       time wget --progress=dot:giga "$DOWNLOAD_URL/$2"
     fi


### PR DESCRIPTION
## summary :

Replaced the deprecated mirror site https://dumps.wikimedia.your.org/ with https://dumps.wikimedia.org/ and enhanced the fallback to wget since the torrent link is also deprecated and redirects to another link.


## Problem faced : 

when running the `buildDatabase.sh` script, you get : 


```bash
[INFO] Download date: 20220820
[INFO] Download URL: https://dumps.wikimedia.your.org/enwiki/20220820
[INFO] Output directory: dump


[INFO] Downloading sha1sums file via wget
--2025-10-18 14:23:39--  https://dumps.wikimedia.your.org/enwiki/20220820/enwiki-20220820-sha1sums.txt
Resolving dumps.wikimedia.your.org (dumps.wikimedia.your.org)... 163.237.219.7, 2001:4978:1000:1499::7
Connecting to dumps.wikimedia.your.org (dumps.wikimedia.your.org)|163.237.219.7|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 42097 (41K) [text/plain]
Saving to: 'enwiki-20220820-sha1sums.txt'

     0K                                    100% 84.4M=0s

2025-10-18 14:23:39 (84.4 MB/s) - 'enwiki-20220820-sha1sums.txt' saved [42097/42097]


real    0m0.469s
user    0m0.040s
sys     0m0.005s

[INFO] Downloading redirects file via torrent

10/18 14:23:40 [ERROR] CUID#7 - Download aborted. URI=https://tools.wmflabs.org/dump-torrents/enwiki/20220820/enwiki-20220820-redirect.sql.gz.torrent
Exception: [AbstractCommand.cc:351] errorCode=22 URI=https://dump-torrents.toolforge.org/enwiki/20220820/enwiki-20220820-redirect.sql.gz.torrent
  -> [HttpSkipResponseCommand.cc:239] errorCode=22 The response status is not successful. status=410

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
146290|ERR |       0B/s|https://tools.wmflabs.org/dump-torrents/enwiki/20220820/enwiki-20220820-redirect.sql.gz.torrent

Status Legend:
(ERR):error occurred.

aria2 will resume download if the transfer is restarted.
If there are any errors, then see the log file. See '-l' option in help/man page for details.

real    0m0.588s
user    0m0.021s
sys     0m0.008s
```

so the problems are : 

- The `.your.org` mirror is deprecated and has sql dumps up to 2022 only.
- The torrent file is also not available and the script doesnt fallback to wget gracefully in that case.


This PR fixes those issues by updating the links and using: 

- `https://dumps.wikimedia.org/enwiki` instead of `https://dumps.wikimedia.your.org/enwiki`
- `https://dump-torrents.toolforge.org/enwiki` instead of `https://tools.wmflabs.org/dump-torrents/enwiki`

note that for the torrent link i only replaced it by what the old link redirects to, the page says that the torrents are no longer available and i dont know any good torrent mirror.

Also the script now doesnt quit when the torrent download fails and simply uses wget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database build reliability with enhanced error handling and validation logic.
  * Updated infrastructure endpoints for more stable download operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->